### PR TITLE
Check existence of path before chdir

### DIFF
--- a/lib/motion/project/vendor.rb
+++ b/lib/motion/project/vendor.rb
@@ -90,9 +90,11 @@ module Motion; module Project
           end
         end
       end
-      Dir.chdir(@path) do
-        if File.exist?(bridgesupport_build_path)
-          FileUtils.rm bridgesupport_build_path
+      if File.exist?(@path)
+        Dir.chdir(@path) do
+          if File.exist?(bridgesupport_build_path)
+            FileUtils.rm bridgesupport_build_path
+          end
         end
       end
     end


### PR DESCRIPTION
If I run a `rake clean:all` twice in a row, the second time I get an error:

```
Errno::ENOENT: No such file or directory @ dir_chdir - ./vendor/Pods/Fabric/OSX/Fabric.framework
/Library/RubyMotion/lib/motion/project/vendor.rb:93:in `chdir'
/Library/RubyMotion/lib/motion/project/vendor.rb:93:in `clean'
/Library/RubyMotion/lib/motion/project/xcode_config.rb:604:in `block in clean_project'
/Library/RubyMotion/lib/motion/project/xcode_config.rb:604:in `each'
/Library/RubyMotion/lib/motion/project/xcode_config.rb:604:in `clean_project'
/Library/RubyMotion/lib/motion/project.rb:47:in `block in <top (required)>'
/Library/RubyMotion/lib/motion/project.rb:53:in `block (2 levels) in <top (required)>'
```

This PR checks for the existence of the directory before changing into it.